### PR TITLE
Render response prior to trying to read its attributes

### DIFF
--- a/batch_requests/views.py
+++ b/batch_requests/views.py
@@ -72,24 +72,16 @@ def get_response(wsgi_request):
     except Exception as exc:
         response = HttpResponseServerError(content=str(exc))
 
+    # Make sure that the response has been rendered
+    if hasattr(response, 'render') and callable(response.render):
+        response = response.render()
+
     # Convert HTTP response into simple dict type.
     result = {
         'status_code': response.status_code,
         'reason_phrase': response.reason_phrase,
         'headers': dict(response._headers.values()),
     }
-
-    # There's some kind of bug here where JSON-API calls are getting
-    # their content-type changed to "text/html". This interferes with
-    # clients detecting and decoding properly. If the request is in
-    # JSON-API, so too shall be the response.
-    # TODO: Figure out what's going on here.
-    if wsgi_request.content_type.startswith('application/vnd.api+json'):
-        result['headers']['Content-Type'] = 'application/vnd.api+json'
-
-    # Make sure that the response has been rendered
-    if hasattr(response, 'render') and callable(response.render):
-        response.render()
 
     content = response.content
     if isinstance(content, bytes):


### PR DESCRIPTION
This ensures the response contains all the correct headers (content type etc.) that it requires prior to preparing the result object.